### PR TITLE
Allow excluding tags

### DIFF
--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -18,26 +18,30 @@ def process_response(response):
     return response.json()
 
 
-def get_articles(tags, per_page=12, page=1, exclude=None, category=None):
-    url_parts = [
-        API_URL,
-        "/posts?",
-        "&per_page=",
-        str(per_page),
-        "&page=",
-        str(page),
-    ]
-
-    if tags:
-        url_parts = url_parts + ["&tags=", str(tags)]
-
-    if exclude:
-        url_parts = url_parts + ["&exclude=", str(exclude)]
-
-    if category:
-        url_parts = url_parts + ["&categories=", str(category)]
-
-    url = "".join(url_parts)
+def get_articles(
+    tags=None,
+    per_page=12,
+    page=1,
+    tags_exclude=[],
+    exclude=None,
+    categories=None,
+):
+    """
+    Get articles from Wordpress api
+    :param tags: Comma separated string of tags to fetch articles for
+    :param per_page: Articles to get per page
+    :param page: Page number to get
+    :param tags_exclude: Array of IDs of tags that will be excluded
+    :param exclude: Comma separated string of article IDs to be excluded
+    :param category: Comma separated list of categories, which articles
+        should be fetched
+    """
+    url = (
+        f"{API_URL}/posts?per_page={per_page}&tags={tags}",
+        f"&page={page}",
+        f"&tags_exclude={','.join(str(id) for id in tags_exclude)}",
+        f"&categories={categories}&exclude={exclude}",
+    )
 
     response = api_session.get(url)
     total_pages = response.headers.get("X-WP-TotalPages")
@@ -45,16 +49,19 @@ def get_articles(tags, per_page=12, page=1, exclude=None, category=None):
     return process_response(response), total_pages
 
 
-def get_article(slug, tags=None, excluded_tags=None):
-    url = "".join([API_URL, "/posts?slug=", slug])
-    if tags:
-        url = url + "&tags=" + ",".join(str(tag) for tag in tags)
-    if excluded_tags:
-        url = (
-            url
-            + "&tags_exclude="
-            + ",".join((str(tag) for tag in excluded_tags))
-        )
+def get_article(slug, tags=[], tags_exclude=[]):
+    """
+    Get an article from Wordpress api
+    :param slug: Article slug to fetch
+    :param tags: Array tags to fetch articles for
+    :param tags_exclude: Array of IDs of tags that will be excluded
+        should be fetched
+    """
+    url = (
+        f"{API_URL}/posts?slug={slug}"
+        f"&tags={','.join(str(id) for id in tags)}"
+        f"&tags_exclude={','.join(str(id) for id in tags_exclude)}"
+    )
 
     response = api_session.get(url)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="1.0.1",
+    version="1.1.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/blog-extension",

--- a/tests/test_wordpress_api.py
+++ b/tests/test_wordpress_api.py
@@ -2,7 +2,6 @@ import unittest
 
 from unittest.mock import patch
 from canonicalwebteam.blog import wordpress_api as api
-from canonicalwebteam.http import CachedSession
 
 
 class MockResponse:
@@ -20,7 +19,8 @@ class TestWordPressApi(unittest.TestCase):
 
         article = api.get_article(slug="test")
         get.assert_called_once_with(
-            "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=test"
+            "https://admin.insights.ubuntu.com/wp-json/wp/v2/"
+            + "posts?slug=test&tags=&tags_exclude="
         )
         self.assertEqual(article, "hello_test")
 
@@ -29,10 +29,10 @@ class TestWordPressApi(unittest.TestCase):
 
         get.return_value = MockResponse()
 
-        article = api.get_article(slug="test", excluded_tags=[1234, 5678])
+        article = api.get_article(slug="test", tags_exclude=[1234, 5678])
         get.assert_called_once_with(
             "https://admin.insights.ubuntu.com/"
-            + "wp-json/wp/v2/posts?slug=test&tags_exclude=1234,5678"
+            + "wp-json/wp/v2/posts?slug=test&tags=&tags_exclude=1234,5678"
         )
         self.assertEqual(article, "hello_test")
 
@@ -45,6 +45,7 @@ class TestWordPressApi(unittest.TestCase):
         get.assert_called_once_with(
             "https://admin.insights.ubuntu.com/"
             + "wp-json/wp/v2/posts?slug=test&tags=1234,5678"
+            + "&tags_exclude="
         )
         self.assertEqual(article, "hello_test")
 
@@ -54,7 +55,7 @@ class TestWordPressApi(unittest.TestCase):
         get.return_value = MockResponse()
 
         article = api.get_article(
-            slug="test", tags=[1234, 5678], excluded_tags=[9876]
+            slug="test", tags=[1234, 5678], tags_exclude=[9876]
         )
         get.assert_called_once_with(
             "https://admin.insights.ubuntu.com/"

--- a/tests/test_wordpress_api.py
+++ b/tests/test_wordpress_api.py
@@ -1,0 +1,63 @@
+import unittest
+
+from unittest.mock import patch
+from canonicalwebteam.blog import wordpress_api as api
+from canonicalwebteam.http import CachedSession
+
+
+class MockResponse:
+    ok = True
+
+    def json(self):
+        return "hello_test"
+
+
+class TestWordPressApi(unittest.TestCase):
+    @patch("canonicalwebteam.http.CachedSession.get")
+    def test_getting_all_articles(self, get):
+
+        get.return_value = MockResponse()
+
+        article = api.get_article(slug="test")
+        get.assert_called_once_with(
+            "https://admin.insights.ubuntu.com/wp-json/wp/v2/posts?slug=test"
+        )
+        self.assertEqual(article, "hello_test")
+
+    @patch("canonicalwebteam.http.CachedSession.get")
+    def test_excluding_articles(self, get):
+
+        get.return_value = MockResponse()
+
+        article = api.get_article(slug="test", excluded_tags=[1234, 5678])
+        get.assert_called_once_with(
+            "https://admin.insights.ubuntu.com/"
+            + "wp-json/wp/v2/posts?slug=test&tags_exclude=1234,5678"
+        )
+        self.assertEqual(article, "hello_test")
+
+    @patch("canonicalwebteam.http.CachedSession.get")
+    def test_including_articles(self, get):
+
+        get.return_value = MockResponse()
+
+        article = api.get_article(slug="test", tags=[1234, 5678])
+        get.assert_called_once_with(
+            "https://admin.insights.ubuntu.com/"
+            + "wp-json/wp/v2/posts?slug=test&tags=1234,5678"
+        )
+        self.assertEqual(article, "hello_test")
+
+    @patch("canonicalwebteam.http.CachedSession.get")
+    def test_including_and_excluding_articles(self, get):
+
+        get.return_value = MockResponse()
+
+        article = api.get_article(
+            slug="test", tags=[1234, 5678], excluded_tags=[9876]
+        )
+        get.assert_called_once_with(
+            "https://admin.insights.ubuntu.com/"
+            + "wp-json/wp/v2/posts?slug=test&tags=1234,5678&tags_exclude=9876"
+        )
+        self.assertEqual(article, "hello_test")


### PR DESCRIPTION
# Done
Extends api to fetch all except excluded tags according to https://developer.wordpress.org/rest-api/reference/posts/

# QA
- The test should reflect the URL building correctly. Run with `python -m unittest tests/test_wordpress_api.py`