### PR TITLE
Adds JSON API endpoint to fetch latest news

### DIFF
--- a/canonicalwebteam/blog/django/urls.py
+++ b/canonicalwebteam/blog/django/urls.py
@@ -4,6 +4,7 @@ from canonicalwebteam.blog.django.views import (
     article_redirect,
     article,
     feed,
+    latest_news,
 )
 
 
@@ -47,6 +48,7 @@ urlpatterns = [
     path(r"/<yyyy:year>/<mm:month>/<str:slug>", article_redirect),
     path(r"/<yyyy:year>/<str:slug>", article_redirect),
     path(r"/feed", feed),
+    path(r"/latest-news", latest_news),
     path(r"/<str:slug>", article, name="article"),
     path(r"", index),
 ]

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import HttpResponseNotFound, HttpResponse
+from django.http import HttpResponseNotFound, HttpResponse, JsonResponse
 from django.shortcuts import render, redirect
 from canonicalwebteam.blog import wordpress_api as api
 from canonicalwebteam.blog import logic
@@ -60,3 +60,29 @@ def article(request, slug):
     context = get_article_context(article)
 
     return render(request, "blog/article.html", context)
+
+
+def latest_news(request):
+    try:
+        latest_articles = api.get_articles(
+            tags=tags_id,
+            exclude=excluded_tags,
+            page=2,
+            per_page=3,
+            sticky=False,
+        )
+        latest_pinned_articles = api.get_articles(
+            tags=tags_id,
+            exclude=excluded_tags,
+            page=1,
+            per_page=1,
+            sticky=True,
+        )
+    except Exception as e:
+        return HttpResponse("Error: " + e, status=502)
+    return JsonResponse(
+        {
+            "latest_articles": latest_articles,
+            "latest_pinned_articles": latest_pinned_articles,
+        }
+    )

--- a/canonicalwebteam/blog/django/views.py
+++ b/canonicalwebteam/blog/django/views.py
@@ -63,11 +63,12 @@ def article(request, slug):
 
 
 def latest_news(request):
+
     try:
         latest_articles = api.get_articles(
             tags=tags_id,
             exclude=excluded_tags,
-            page=2,
+            page=1,
             per_page=3,
             sticky=False,
         )
@@ -78,8 +79,8 @@ def latest_news(request):
             per_page=1,
             sticky=True,
         )
-    except Exception as e:
-        return HttpResponse("Error: " + e, status=502)
+    except Exception:
+        return JsonResponse({"Error": "An error ocurred"}, status=502)
     return JsonResponse(
         {
             "latest_articles": latest_articles,

--- a/canonicalwebteam/blog/flask/views.py
+++ b/canonicalwebteam/blog/flask/views.py
@@ -73,7 +73,7 @@ def build_blueprint(blog_title, tags_id, tag_name, excluded_tags=[]):
             latest_articles = api.get_articles(
                 tags=tags_id,
                 exclude=excluded_tags,
-                page=2,
+                page=1,
                 per_page=3,
                 sticky=False,
             )
@@ -84,9 +84,8 @@ def build_blueprint(blog_title, tags_id, tag_name, excluded_tags=[]):
                 per_page=1,
                 sticky=True,
             )
-        except Exception as e:
-            print(e)
-            return flask.abort(502)
+        except Exception:
+            return flask.jsonify({"Error": "An error ocurred"}), 502
 
         return flask.jsonify(
             {

--- a/canonicalwebteam/blog/flask/views.py
+++ b/canonicalwebteam/blog/flask/views.py
@@ -8,7 +8,7 @@ from canonicalwebteam.blog.common_view_logic import (
 )
 
 
-def build_blueprint(blog_title, tags_id, tag_name):
+def build_blueprint(blog_title, tags_id, tag_name, excluded_tags=[]):
     blog = flask.Blueprint(
         "blog", __name__, template_folder="/templates", static_folder="/static"
     )
@@ -66,5 +66,33 @@ def build_blueprint(blog_title, tags_id, tag_name):
         context = get_article_context(articles)
 
         return flask.render_template("blog/article.html", **context)
+
+    @blog.route("/latest-news")
+    def latest_news():
+        try:
+            latest_articles = api.get_articles(
+                tags=tags_id,
+                exclude=excluded_tags,
+                page=2,
+                per_page=3,
+                sticky=False,
+            )
+            latest_pinned_articles = api.get_articles(
+                tags=tags_id,
+                exclude=excluded_tags,
+                page=1,
+                per_page=1,
+                sticky=True,
+            )
+        except Exception as e:
+            print(e)
+            return flask.abort(502)
+
+        return flask.jsonify(
+            {
+                "latest_articles": latest_articles,
+                "latest_pinned_articles": latest_pinned_articles,
+            }
+        )
 
     return blog

--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -43,8 +43,9 @@ def get_articles(
         f"&tags_exclude={','.join(str(id) for id in tags_exclude)}"
         f"&categories={','.join(str(id) for id in categories)}"
         f"&exclude={','.join(str(id) for id in exclude)}"
-        f"&sticky={sticky}"
     )
+    if sticky != "":
+        url = url + f"&sticky={sticky}"
 
     response = api_session.get(url)
     total_pages = response.headers.get("X-WP-TotalPages")

--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -18,7 +18,13 @@ def process_response(response):
 
 
 def get_articles(
-    tags=[], per_page=12, page=1, tags_exclude=[], exclude=[], categories=[]
+    tags=[],
+    per_page=12,
+    page=1,
+    tags_exclude=[],
+    exclude=[],
+    categories=[],
+    sticky="",
 ):
     """
     Get articles from Wordpress api
@@ -37,6 +43,7 @@ def get_articles(
         f"&tags_exclude={','.join(str(id) for id in tags_exclude)}"
         f"&categories={','.join(str(id) for id in categories)}"
         f"&exclude={','.join(str(id) for id in exclude)}"
+        f"&sticky={sticky}"
     )
 
     response = api_session.get(url)

--- a/tests/test_wordpress_api.py
+++ b/tests/test_wordpress_api.py
@@ -83,6 +83,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude="
             + "&categories="
             + "&exclude="
+            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -101,6 +102,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude="
             + "&categories="
             + "&exclude="
+            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -119,6 +121,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude=1234,5678"
             + "&categories="
             + "&exclude="
+            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -137,6 +140,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude="
             + "&categories="
             + "&exclude="
+            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -155,6 +159,7 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude=9876"
             + "&categories="
             + "&exclude="
+            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -173,5 +178,25 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude="
             + "&categories=5678"
             + "&exclude="
+            + "&sticky="
+        )
+        self.assertEqual(article, (["hello_test"], 12))
+
+    @patch("canonicalwebteam.http.CachedSession.get")
+    def test_getting_sticky_only(self, get):
+
+        get.return_value = MockResponse()
+
+        article = api.get_articles(sticky=True)
+        get.assert_called_once_with(
+            "https://admin.insights.ubuntu.com/"
+            + "wp-json/wp/v2/posts?"
+            + "per_page=12"
+            + "&tags="
+            + "&page=1"
+            + "&tags_exclude="
+            + "&categories="
+            + "&exclude="
+            + "&sticky=True"
         )
         self.assertEqual(article, (["hello_test"], 12))

--- a/tests/test_wordpress_api.py
+++ b/tests/test_wordpress_api.py
@@ -83,7 +83,6 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude="
             + "&categories="
             + "&exclude="
-            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -102,7 +101,6 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude="
             + "&categories="
             + "&exclude="
-            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -121,7 +119,6 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude=1234,5678"
             + "&categories="
             + "&exclude="
-            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -140,7 +137,6 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude="
             + "&categories="
             + "&exclude="
-            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -159,7 +155,6 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude=9876"
             + "&categories="
             + "&exclude="
-            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 
@@ -178,7 +173,6 @@ class TestWordPressApi(unittest.TestCase):
             + "&tags_exclude="
             + "&categories=5678"
             + "&exclude="
-            + "&sticky="
         )
         self.assertEqual(article, (["hello_test"], 12))
 


### PR DESCRIPTION
# Done
- Adds endpoints to Flask and Django to receive latest news
- Adds new parameter to `wordpress_api` to get **sticky** posts only

# QA
Verify that the tests work. They should reflect the new URL building 