### PR TITLE
Remove import of Django app on blog __init__.py

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,1 +1,2 @@
+1.3.1: Removes import of django app on  __init__.py
 1.3.0: Adds endpoint to fetch latest news

--- a/canonicalwebteam/blog/__init__.py
+++ b/canonicalwebteam/blog/__init__.py
@@ -1,1 +1,0 @@
-from canonicalwebteam.blog.django.apps import DjangoBlogConfig  # noqa: 401

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.blog",
-    version="1.3.0",
+    version="1.3.1",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-webteam/blog-extension",


### PR DESCRIPTION
# Done
Removes Django app import, since this would break when the module is loaded into non Django environments